### PR TITLE
do not throw when substituting phantom methods

### DIFF
--- a/substitute.js
+++ b/substitute.js
@@ -4,6 +4,7 @@ var Promise = require('promise')
 exports = module.exports = substitute
 
 function substitute(db, methodName, method) {
+  if (typeof method !== 'function') return
   db[methodName] = _wrap(method, Promise.denodeify(method))
 }
 

--- a/test/substitute.js
+++ b/test/substitute.js
@@ -13,7 +13,8 @@ describe('substitute', function() {
     , PROMISE_METHOD = sinon.spy()
 
   Promise.denodeify = sinon.stub()
-  Promise.denodeify.returns(PROMISE_METHOD)
+  Promise.denodeify.withArgs(METHOD).returns(PROMISE_METHOD)
+  Promise.denodeify.withArgs(undefined).throws(Error('no method to denodify'))
 
   beforeEach(function() {
     METHOD.reset()
@@ -41,4 +42,11 @@ describe('substitute', function() {
     expect(METHOD.calledOnce).to.be.true
     expect(PROMISE_METHOD.called).to.be.false
   })
+
+  it('does not throw if no method is given', function () {
+    expect(function () {
+      substitute(DB, METHOD_NAME, undefined)
+    }).not.to.throw()
+  })
+
 })


### PR DESCRIPTION
Sometimes the manifest is not right.
For example, right now it gives me `approximateSize()` which is not directly available on levelup anymore.

This patch ignores substitutions when trying to substitute a method that is not there.
